### PR TITLE
nb::any is removed in nanobind v2.0.0

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -21,6 +21,9 @@ If you want to use AEStream with CUDA support, you likely need to build the pack
 To do so, simply run `pip install aestream --no-binary aestream` to avoid using the binary cache.
 It will take a few minutes to compile, but if you have an NVIDIA GPU, you'll see dramatic performance improvements.
 Note that you can provide a `-v` flag to enable verbose output, which will show you if the CUDA drivers were detected (look for `CUDA found`).
+If you need to specify a different C++ compiler, be sure to also specify it for NVCC:
+
+```CXX=/path/to/g++-10 NVCC_PREPEND_FLAGS='-ccbin /path/to/g++-10' pip install aestream --no-binary aestream```
 
 ### Event camera drivers
 AEStream can read from [Inivation](https://gitlab.com/inivation/dv/libcaer/) or [Prophesee](https://github.com/prophesee-ai/openeb/) event cameras, *given that the drivers are installed*.

--- a/src/python/file.cpp
+++ b/src/python/file.cpp
@@ -40,7 +40,7 @@ bool FileInput::get_is_streaming() {
   return is_streaming.load() || is_nonempty.load();
 }
 
-nb::ndarray<nb::numpy, uint8_t, nb::shape<1, nb::any>> FileInput::load() {
+nb::ndarray<nb::numpy, uint8_t, nb::shape<1, -1>> FileInput::load() {
   struct Container {
     std::vector<AER::Event> events;
   };
@@ -49,7 +49,7 @@ nb::ndarray<nb::numpy, uint8_t, nb::shape<1, nb::any>> FileInput::load() {
   c->events = std::move(arr);
   nb::capsule deleter(c, [](void *p) noexcept { delete (Container *)p; });
   const size_t shape[1] = {n_read * sizeof(AER::Event)};
-  return nb::ndarray<nb::numpy, uint8_t, nb::shape<1, nb::any>>(
+  return nb::ndarray<nb::numpy, uint8_t, nb::shape<1, -1>>(
       c->events.data(), 1, shape, deleter);
 }
 

--- a/src/python/file.hpp
+++ b/src/python/file.hpp
@@ -42,7 +42,7 @@ public:
 
   bool get_is_streaming();
 
-  nb::ndarray<nb::numpy, uint8_t, nb::shape<1, nb::any>> load();
+  nb::ndarray<nb::numpy, uint8_t, nb::shape<1, -1>> load();
 
   FileInput *start_stream();
 

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -96,7 +96,7 @@ NB_MODULE(aestream_ext, m) {
       .def("read_buffer", &FileInput::read)
       .def("read_genn",
            [](FileInput &file,
-              nb::ndarray<uint32_t, nb::shape<nb::any>, nb::c_contig,
+              nb::ndarray<uint32_t, nb::shape<-1>, nb::c_contig,
                           nb::device::cpu>
                   buffer) { file.read_genn(buffer.data(), buffer.size()); });
   //  .def("parts",
@@ -131,7 +131,7 @@ NB_MODULE(aestream_ext, m) {
       .def("read_buffer", &UDPInput::read)
       .def("read_genn",
            [](UDPInput &udp,
-              nb::ndarray<uint32_t, nb::shape<nb::any>, nb::c_contig,
+              nb::ndarray<uint32_t, nb::shape<-1>, nb::c_contig,
                           nb::device::cpu>
                   buffer) { udp.read_genn(buffer.data(), buffer.size()); });
 
@@ -160,7 +160,7 @@ NB_MODULE(aestream_ext, m) {
       .def("read_buffer", &USBInput::read, nb::rv_policy::take_ownership)
       .def("read_genn",
            [](USBInput &usb,
-              nb::ndarray<uint32_t, nb::shape<nb::any>, nb::c_contig,
+              nb::ndarray<uint32_t, nb::shape<-1>, nb::c_contig,
                           nb::device::cpu>
                   buffer) { usb.read_genn(buffer.data(), buffer.size()); });
 #endif
@@ -182,7 +182,7 @@ NB_MODULE(aestream_ext, m) {
       .def("read_buffer", &ZMQInput::read, nb::rv_policy::take_ownership)
       .def("read_genn",
            [](ZMQInput &zmq,
-              nb::ndarray<uint32_t, nb::shape<nb::any>, nb::c_contig,
+              nb::ndarray<uint32_t, nb::shape<-1>, nb::c_contig,
                           nb::device::cpu>
                   buffer) { zmq.read_genn(buffer.data(), buffer.size()); });
 #endif

--- a/src/python/tensor_buffer.hpp
+++ b/src/python/tensor_buffer.hpp
@@ -25,9 +25,9 @@ template <typename scalar_t> void delete_cpu_buffer(scalar_t *ptr) {
   delete[] ptr;
 }
 
-using tensor_jax = nb::ndarray<nb::jax, float, nb::shape<nb::any>>;
-using tensor_numpy = nb::ndarray<nb::numpy, float, nb::shape<nb::any>>;
-using tensor_torch = nb::ndarray<nb::pytorch, float, nb::shape<nb::any>>;
+using tensor_jax = nb::ndarray<nb::jax, float, nb::shape<-1>>;
+using tensor_numpy = nb::ndarray<nb::numpy, float, nb::shape<-1>>;
+using tensor_torch = nb::ndarray<nb::pytorch, float, nb::shape<-1>>;
 using buffer_t = std::unique_ptr<float[], void (*)(float *)>;
 using index_t = std::unique_ptr<int[], void (*)(int *)>;
 


### PR DESCRIPTION
I tried to build aestream with libcaer and CUDA support, but ran into errors. It turns out that nanobind [recently](https://nanobind.readthedocs.io/en/latest/changelog.html#version-2-0-0-may-23-2024) removed `nb::any` support in `nb::shape`, and that one should now use `-1` instead. This PR fixes that here, and allows me to compile successfully with `pip install git+https://github.com/Huizerd/aestream@dev/nb_any_bug --no-binary aestream -v`.

Tested on Ubuntu 20.04, with `gcc-10` and `g++-10` selected via `update-alternatives` as explained [here](https://askubuntu.com/questions/26498/how-to-choose-the-default-gcc-and-g-version). I have the latest libcaer master from [here](https://gitlab.com/inivation/dv/libcaer) and CUDA toolkit 12.1 from [here](https://developer.nvidia.com/cuda-12-1-0-download-archive).

I also got it built successfully in a conda environment:
```yaml
name: cuda_minimal
channels:
  - pytorch
  - nvidia
dependencies:
  - python=3.11
  - pytorch-cuda=12.1
  - pytorch==2.1.2
  - torchvision==0.16.2
  - cuda=12.1
  - cuda-nvcc=12.1
  - cuda-version=12.1
  - pip
  - pip:
    - cmake
    - numpy
    - setuptools
    - wheel
```

Also, when I didn't have `g++-10` set as default and tried to build with CUDA support, I found that setting only `CXX=g++-10` wasn't enough; you also have to set the host compiler for CUDA as follows:
```
CXX=g++-10 NVCC_PREPEND_FLAGS='-ccbin g++-10' pip install git+https://github.com/Huizerd/aestream@dev/nb_any_bug --no-binary aestream -v
```

Maybe this could be added in the docs :)