### PR TITLE
Correct CSV parsing logic

### DIFF
--- a/src/cpp/file/csv.hpp
+++ b/src/cpp/file/csv.hpp
@@ -19,10 +19,10 @@ struct CSV : FileBase {
     while (std::getline(file_stream, line) &&
            (n_events < 0 || sum < n_events)) {
       std::regex_match(line, event_match, csv_regex);
-      uint64_t timestamp = static_cast<uint64_t>(std::stol(event_match[0]));
-      uint16_t x = static_cast<uint16_t>(std::stol(event_match[1]));
-      uint16_t y = static_cast<uint16_t>(std::stol(event_match[2]));
-      co_yield AER::Event{timestamp, x, y, std::stoi(event_match[3]) > 0};
+      uint64_t timestamp = static_cast<uint64_t>(std::stol(event_match[1]));
+      uint16_t x = static_cast<uint16_t>(std::stol(event_match[2]));
+      uint16_t y = static_cast<uint16_t>(std::stol(event_match[3]));
+      co_yield AER::Event{timestamp, x, y, std::stoi(event_match[4]) > 0};
       sum++;
     }
     co_return;


### PR DESCRIPTION
The .csv input was generating bad event output, something like
`correct timestamp, gibberish, correct x coordinate, polarity always true`

This was because the `event_match` object contains:
- on line 0, the entire matched string (in this case, the entire line from the csv)
- on line 1, the value of the timestamp
- on line 2, the value of x
and so on. 

So:
Timestamp was correct because the cast to uint64 only considered the digits before the comma. 
Gibberish is the result of timestamp casting to uint16.
The always true polarity is because the y coordinate is always more than 0 in my tests.

Notice that tests pass nevertheless because in the sample csv file, the timestamp is always equal to the coordinates, and polarity is not checked. 

With the simple correction proposed, the bug can be resolved. 